### PR TITLE
updated for b18

### DIFF
--- a/ED-LaserDrill/About/About.xml
+++ b/ED-LaserDrill/About/About.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetaData>
 	<name>ED-Laser Drill</name>
-	<targetVersion>0.17.0</targetVersion>
+	<targetVersion>0.18.0</targetVersion>
 	<author>Jaxxa</author>
 	<url>https://ludeon.com/forums/index.php?topic=18995.0</url>
-	<description>Version: 0.17.0
+	<description>Version: 0.18.0
 Discussion, Non Steam Downloads and GitHub Repositories of this mod is available at: https://ludeon.com/forums/index.php?topic=18995
 
 Adds a Laser Drill that allows the creation of new steam vents, and a Laser Filler that allows you to remove unwanted steam vents.

--- a/ED-LaserDrill/Defs/ResearchProjectDefs/LaserResearchProject.xml
+++ b/ED-LaserDrill/Defs/ResearchProjectDefs/LaserResearchProject.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ResearchProjectDefs>
+<Defs>
 
 	<ResearchProjectDef>
 		<defName>Research_LaserSteamGeyser_Drill</defName>
@@ -28,4 +28,4 @@
 		<researchViewY>0</researchViewY>
 	</ResearchProjectDef>
 
-</ResearchProjectDefs>
+</Defs>

--- a/ED-LaserDrill/Defs/ThingDefs_Buildings/laserDrills.xml
+++ b/ED-LaserDrill/Defs/ThingDefs_Buildings/laserDrills.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ThingDefs>
+<Defs>
 
 
 	<!--================================ Abstract bases ======================================-->
@@ -113,7 +113,6 @@
 		<staticSunShadowHeight>1.0</staticSunShadowHeight>
 		<building>
 			<soundAmbient>GeothermalPlant_Ambience</soundAmbient>
-			<ignoreNeedsPower>true</ignoreNeedsPower>
 		</building>
 		<researchPrerequisites>
 			<li>Research_LaserSteamGeyser_Filler</li>
@@ -121,4 +120,4 @@
 	</ThingDef>
 
 
-</ThingDefs>
+</Defs>

--- a/Source/ED-LaserDrill/ED-LaserDrill.csproj
+++ b/Source/ED-LaserDrill/ED-LaserDrill.csproj
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\lib\A17\1527\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\lib\A17\1557\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
@@ -41,7 +41,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\lib\A17\1527\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\lib\A17\1557\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
Note: I don't have access to Visual Studio, so I wasn't able to compile the DLL. I get the following error with the a17 DLL:

```
Exception ticking LaserDrill36804: System.TypeLoadException: Could not load type 'Verse.MessageSound' from assembly 'Assembly-CSharp, Version=0.17.6362.34395, Culture=neutral, PublicKeyToken=null'.
  at Verse.TickList.Tick () [0x00000] in <filename unknown>:0 
Verse.Log:Error(String)
Verse.TickList:Tick()
Verse.TickManager:DoSingleTick()
Verse.TickManager:TickManagerUpdate()
Verse.Game:UpdatePlay()
Verse.Root_Play:Update()
```

<ignoreNeedsPower> seems to be deprecated or unnecessary. I removed it because it was causing errors loading the mod...