### PR TITLE
Fix typo in Laser Drill Building name

### DIFF
--- a/ED-LaserDrill/1.1/Defs/ThingDefs/Buildings_LaserDrill.xml
+++ b/ED-LaserDrill/1.1/Defs/ThingDefs/Buildings_LaserDrill.xml
@@ -5,7 +5,7 @@
 
 	<ThingDef ParentName="BuildingBase">
 		<defName>LaserDrill</defName>
-		<label>Laser Drill Tageting</label>
+		<label>Laser Drill Targeting</label>
 		<thingClass>Building</thingClass>
 		<graphicData>
 			<texPath>Things/Buildings/LaserDrill</texPath>


### PR DESCRIPTION
The name was misspelled as "tagetting"